### PR TITLE
fix source name for utmz result

### DIFF
--- a/lib/traffic_source_parser/result/utmz.rb
+++ b/lib/traffic_source_parser/result/utmz.rb
@@ -6,6 +6,18 @@ module TrafficSourceParser
 
       def initialize(utmz_hash)
         super(utmz_hash)
+
+        self[:source] = get_known_source(utmz_hash) if use_known_sources?(utmz_hash)
+      end
+
+      private
+
+      def use_known_sources?(utmz_hash)
+        TrafficSourceParser::Parser::ReferrerParser.referrers_list.has_key?(utmz_hash[:source])
+      end
+
+      def get_known_source(utmz_hash)
+        TrafficSourceParser::Parser::ReferrerParser.referrers_list[utmz_hash[:source]]['source']
       end
 
     end

--- a/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
+++ b/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
@@ -25,7 +25,7 @@ describe TrafficSourceParser::Parser::UtmzParser do
           let(:campaign) { '(referral)' }
           let(:medium) { 'referral' }
           let(:channel) { 'Social' }
-          let(:source) { 't.co' }
+          let(:source) { 'Twitter' }
           let(:content) { '/EFzCFawFrk' }
 
           it_behaves_like 'a traffic source campaign parser with content'
@@ -36,7 +36,7 @@ describe TrafficSourceParser::Parser::UtmzParser do
           let(:campaign) { 'experimentar-ferramenta' }
           let(:medium) { 'sponsored-post' }
           let(:channel) { 'Social' }
-          let(:source) { 'facebook' }
+          let(:source) { 'Facebook' }
           let(:content) { 'organize-seus-negocios' }
 
           it_behaves_like 'a traffic source campaign parser with content'
@@ -47,49 +47,12 @@ describe TrafficSourceParser::Parser::UtmzParser do
           let(:campaign) { '20150528-ef-aprovacaoharvard' }
           let(:medium) { 'socialmedia-fe' }
           let(:channel) { 'Social' }
-          let(:source) { 'facebook.com' }
+          let(:source) { 'Facebook' }
 
           it_behaves_like 'a traffic source campaign parser'
         end
 
       end
-
-      # context 'when value is from referral' do
-      #   {
-      #     cookie_value: "210677130.1432831711.1.1.utmcsr=rakuten|utmc" +
-      #                   "cn=linkshare|utmcmd=(not set)",
-      #     source: "rakuten",
-      #     campaign: "linkshare",
-      #     channel: "Referral",
-      #     medium: "(not set)"
-      #   }
-      # end
-      #
-      # context 'when value is from other advertising' do
-      #   {
-      #     cookie_value: "10083233.1432828147.6.5.utmcsr=newsletter|ut" +
-      #                   "mccn=20150527|utmcmd=newsletter-ef|utmctr=communi" +
-      #                   "tycolleges|utmcct=programa",
-      #     source: "newsletter",
-      #     campaign: "20150527",
-      #     channel: "Other",
-      #     medium: "newsletter-ef",
-      #     term: "communitycolleges",
-      #     content: "programa"
-      #   }
-      # end
-      #
-      # context 'when value is from CPC campaign' do
-      #   {
-      #     cookie_value: "63514687.1432831892.1.1.utmcsr=adwords_gereb" +
-      #                   "oletos1min5_22072014|utmgclid=CNjQrtjy5MUCFQYXHwo" +
-      #                   "d7k0A8g|utmccn=(not set)|utmcmd=(not set)",
-      #     source: "adwords_gereboletos1min5_22072014",
-      #     campaign: "(not set)",
-      #     channel: "Paid Search",
-      #     medium: "cpc"
-      #   }
-      # end
 
     end
 


### PR DESCRIPTION
Insere o nome correto do Source caso ele exista no yaml, garantindo consistência entre utmz e referral parsers.
