### PR TITLE
[Mushin] Channel Definition

### DIFF
--- a/lib/traffic_source_parser/channels.rb
+++ b/lib/traffic_source_parser/channels.rb
@@ -9,14 +9,14 @@ module TrafficSourceParser
 
     AVAILABLE_TYPES = [
       Types::OtherAdvertising,
-      Types::Social,
       Types::Referral,
       Types::Display,
       Types::Direct,
       Types::Organic,
-      Types::Paid,
       Types::Email,
-      Types::Unknown
+      Types::Unknown,
+      Types::Paid,
+      Types::Social
     ]
 
     def define_channel(traffic_source)

--- a/lib/traffic_source_parser/channels/types/social.rb
+++ b/lib/traffic_source_parser/channels/types/social.rb
@@ -12,7 +12,7 @@ module TrafficSourceParser
             'Social'
           end
 
-          # Traffic from any of approximately 400 social networks (that are not tagged as ads).
+          # Traffic from any of approximately 400 social networks (that are not tagged as other channel).
           def match_source?(traffic_source)
             traffic_source[:medium] =~ SOCIAL_REGEX || get_known_social(traffic_source[:source])
           end

--- a/lib/traffic_source_parser/version.rb
+++ b/lib/traffic_source_parser/version.rb
@@ -1,3 +1,3 @@
 module TrafficSourceParser
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/lib/traffic_source_parser/parser/campaign_parser_spec.rb
+++ b/spec/lib/traffic_source_parser/parser/campaign_parser_spec.rb
@@ -16,10 +16,20 @@ describe TrafficSourceParser::Parser::CampaignParser do
       it_behaves_like 'a traffic source campaign parser'
     end
 
-    context 'when value is from ppc but source is social' do
+    context 'when value is from ppc and source is Social' do
       let(:cookie) { 'utm_source=facebook&utm_medium=ppc&utm_campaign=fb_retargeting_1' }
       let(:campaign) { 'fb_retargeting_1' }
       let(:medium) { 'ppc' }
+      let(:channel) { 'Paid Search' }
+      let(:source) { 'Facebook' }
+
+      it_behaves_like 'a traffic source campaign parser'
+    end
+
+    context 'when value does not have medium but source is from social' do
+      let(:cookie) { 'utm_source=facebook&utm_campaign=fb_retargeting_2' }
+      let(:campaign) { 'fb_retargeting_2' }
+      let(:medium) { nil }
       let(:channel) { 'Social' }
       let(:source) { 'Facebook' }
 

--- a/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
+++ b/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
@@ -64,7 +64,7 @@ describe TrafficSourceParser::Parser::UtmzParser do
           let(:cookie) { '231152653.1432828491.1.1.utmcsr=t.co|utmccn=(referral)|utmcmd=referral|utmcct=/teste' }
           let(:campaign) { '(referral)' }
           let(:medium) { 'referral' }
-          let(:channel) { 'Social' }
+          let(:channel) { 'Referral' }
           let(:source) { 'Twitter' }
           let(:content) { '/teste' }
 

--- a/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
+++ b/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
@@ -48,11 +48,11 @@ describe TrafficSourceParser::Parser::UtmzParser do
         it_behaves_like 'a traffic source campaign parser'
       end
 
-            context 'when medium is ppc but source is social' do
+      context 'when medium is ppc but source is social' do
         let(:cookie) { '78301271.1443725657.1.1.utmcsr=facebook|utmccn=fb_retargeting_1|utmcmd=ppc' }
         let(:campaign) { 'fb_retargeting_1' }
         let(:medium) { 'ppc' }
-        let(:channel) { 'Social' }
+        let(:channel) { 'Paid Search' }
         let(:source) { 'Facebook' }
 
         it_behaves_like 'a traffic source campaign parser'


### PR DESCRIPTION
# What was done

- Check the known social media only after verifying utm_medium from others channels
- Fixes https://github.com/ResultadosDigitais/rdstation/issues/10586

# Setup

```
bin/console
```

# How to test

- [x] CampaignParser - Medium ppc and source is social media
  ```
  cookie  = 'utm_source=facebook&utm_medium=ppc&utm_campaign=fb_retargeting_1'
  TrafficSourceParser::Parser::CampaignParser.parse(cookie)
  ```
  - Channel is Paid Search

- [x] CampaignParser - Medium nil and source is social media
  ```
  cookie  = 'utm_source=facebook&utm_campaign=fb_retargeting_1'
  TrafficSourceParser::Parser::CampaignParser.parse(cookie)
  ```
  - Channel is Social

- [x] UtmzParser - Medium ppc and source is social media
  ```
   cookie = '78301271.1443725657.1.1.utmcsr=facebook|utmccn=fb_retargeting_1|utmcmd=ppc'
  TrafficSourceParser::Parser::UtmzParser.parse(cookie) 
  ```
  - Channel is Paid Search