### PR TITLE
Social network are not refferal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem "codeclimate-test-reporter", group: :test, require: nil

--- a/lib/traffic_source_parser/channels.rb
+++ b/lib/traffic_source_parser/channels.rb
@@ -9,14 +9,14 @@ module TrafficSourceParser
 
     AVAILABLE_TYPES = [
       Types::OtherAdvertising,
-      Types::Referral,
       Types::Display,
       Types::Direct,
       Types::Organic,
       Types::Email,
       Types::Unknown,
       Types::Paid,
-      Types::Social
+      Types::Social,
+      Types::Referral
     ]
 
     def define_channel(traffic_source)

--- a/lib/traffic_source_parser/version.rb
+++ b/lib/traffic_source_parser/version.rb
@@ -1,3 +1,3 @@
 module TrafficSourceParser
-  VERSION = "0.4.1"
+  VERSION = '0.4.2'.freeze
 end

--- a/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
+++ b/spec/lib/traffic_source_parser/parser/utmz_parser_spec.rb
@@ -64,9 +64,20 @@ describe TrafficSourceParser::Parser::UtmzParser do
           let(:cookie) { '231152653.1432828491.1.1.utmcsr=t.co|utmccn=(referral)|utmcmd=referral|utmcct=/teste' }
           let(:campaign) { '(referral)' }
           let(:medium) { 'referral' }
-          let(:channel) { 'Referral' }
+          let(:channel) { 'Social' }
           let(:source) { 'Twitter' }
           let(:content) { '/teste' }
+
+          it_behaves_like 'a traffic source campaign parser with content'
+        end
+
+        context 'from Facebook with content and from referral medium' do
+          let(:cookie) { '9793965.1508981844.1.1.utmcsr=m.facebook.com|utmccn=(referral)|utmcmd=referral|utmcct=/' }
+          let(:campaign) { '(referral)' }
+          let(:medium) { 'referral' }
+          let(:channel) { 'Social' }
+          let(:source) { 'Facebook' }
+          let(:content) { '/' }
 
           it_behaves_like 'a traffic source campaign parser with content'
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,3 @@
-require "codeclimate-test-reporter"
-
-CodeClimate::TestReporter.start
-
 require 'traffic_source_parser'
 require 'pry'
 require 'rspec'


### PR DESCRIPTION
# What was done

- Check the known social media and if so, do not classify as Referral. 

# Setup

```
bin/console
```

# How to test

- [x] CampaignParser - Medium ppc and source is social media

```ruby
cookie = '78301271.1443725657.1.1.utmcsr=facebook|utmccn=fb_retargeting_1|utmcmd=ppc'
TrafficSourceParser.parse(cookie)
```
  - Channel is Paid Search

- [x] CampaignParser - Medium ppc and source is social media

```ruby
cookie = "9793965.1508981844.1.1.utmcsr=m.facebook.com|utmccn=(referral)|utmcmd=referral|utmcct=/"
TrafficSourceParser.parse(cookie)
```
  - Channel is Social

